### PR TITLE
9-double-symbol-return-for-apipath

### DIFF
--- a/pkg/apis/api_gen.go
+++ b/pkg/apis/api_gen.go
@@ -76,7 +76,11 @@ func GenerateAPIList(api Types.OpenAPI) []Types.APIWithDTO {
 
 			for _, param := range operation.Parameters {
 				if param.In == "path" {
-					path = strings.Replace(path, fmt.Sprintf("{%s}", param.Name), fmt.Sprintf("${%s}", Dtos.ToCamelCase(param.Name)), -1)
+					paramAppend := fmt.Sprintf("${%s}", Dtos.ToCamelCase(param.Name))
+
+					if !strings.Contains(path, paramAppend) {
+						path = strings.Replace(path, fmt.Sprintf("{%s}", param.Name), paramAppend, -1)
+					}
 				}
 			}
 


### PR DESCRIPTION
- issue happened on path that is looped, check if the path contains `${param}` ,add checking prevent replace again to `$${param}`.